### PR TITLE
better regex to match tags with appropriate classes

### DIFF
--- a/inc/class-bjll.php
+++ b/inc/class-bjll.php
@@ -324,7 +324,7 @@ class BJLL {
 		$skip_classes_quoted = array_map( 'preg_quote', $skip_classes );
 		$skip_classes_ORed = implode( '|', $skip_classes_quoted );
 
-		$regex = '/<\s*\w*\s*class\s*=\s*[\'"](|.*\s)' . $skip_classes_ORed . '(|\s.*)[\'"].*>/isU';
+		$regex = '/<\w+[^>]*\s*class\s*=\s*[\'"]([^\'"]*\s+|)(' . $skip_classes_ORed . ')(\s+[^\'" ]*|)[\'"][^>]*>/is';
 
 		return preg_replace( $regex, '', $content );
 	}

--- a/inc/class-bjll.php
+++ b/inc/class-bjll.php
@@ -316,7 +316,10 @@ class BJLL {
 	public static function remove_skip_classes_elements( $content ) {
 
 		$skip_classes = self::_get_skip_classes( 'html' );
-
+		if ( count( $skip_classes ) <= 0 ) {
+			return $content;
+		}
+		
 		/*
 		http://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454
 		We can’t do this, but we still do it.
@@ -353,10 +356,6 @@ class BJLL {
 		
 		if ( strlen( trim( $skip_classes_str ) ) ) {
 			$skip_classes = array_map( 'trim', explode( ',', $skip_classes_str ) );
-		}
-
-		if ( ! in_array( 'lazy', $skip_classes ) ) {
-			$skip_classes[] = 'lazy';
 		}
 
 		/**


### PR DESCRIPTION
Original regex causes too much false positives, as a result many posts just match out completely and lazy loading doesn't even start.
This one cause less false positives.